### PR TITLE
fix start server problem + fix typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,7 @@ func main() {
 	case 1:
 		ConfigServer()
 	case 2:
-		color.Success.Println("Your server is now ap and running...")
-		StartServer(ServerPort)
+		DefaultPort()
 	}
 }
 

--- a/ports.go
+++ b/ports.go
@@ -68,6 +68,6 @@ func CustomStaticPort() {
 }
 func DefaultPort() {
 	ServerPort = ":8090"
-	color.Success.Println("Your server is now ap and running...")
+	color.Success.Println("Your server is now up and running...")
 	StartServer(ServerPort)
 }


### PR DESCRIPTION
In the main menu, the short way to directly start the webserver, didnt execute that well, so i changed it so when you insert 2 it will call the DefaultPort() function.
Also there was a typo in the confirmation message.